### PR TITLE
Added property to haml.lang in order to make it work with the code comment plugin.

### DIFF
--- a/lang-specs/haml.lang
+++ b/lang-specs/haml.lang
@@ -6,6 +6,7 @@
   <metadata>
     <property name="mimetypes">text/x-haml</property>
     <property name="globs">*.haml</property>
+    <property name="line-comment-start">//</property>
   </metadata>
   <styles>
     <style id="comment"   _name="Comment"   map-to="def:comment"/>


### PR DESCRIPTION
I added the 'line-comment-start' property to haml.lang in order to make it work with the gedit "code comment" plugin.  Now you can use the code comment keyboard shortcut (Ctrl+M) for quickly (un)commenting code in HAML files.
