### PR TITLE
Fixed line-comment-start-property

### DIFF
--- a/lang-specs/haml.lang
+++ b/lang-specs/haml.lang
@@ -6,7 +6,7 @@
   <metadata>
     <property name="mimetypes">text/x-haml</property>
     <property name="globs">*.haml;*.jade</property>
-    <property name="line-comment-start">//</property>
+    <property name="line-comment-start">-#</property>
   </metadata>
   <styles>
     <style id="comment"   _name="Comment"   map-to="def:comment"/>


### PR DESCRIPTION
A Haml line comment starts with: -#

-- http://haml.info/docs/yardoc/file.REFERENCE.html#haml_comments_
