### PR TITLE
Fix plugin loader not found issue (#153)

### DIFF
--- a/plugins/gedit3/FindInFiles/FindInFiles.plugin
+++ b/plugins/gedit3/FindInFiles/FindInFiles.plugin
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=FindInFiles
 IAge=3
 Name=Find In Files


### PR DESCRIPTION
I was getting the "Error: Plugin loader "python" was not found." issue (#153) on this plugin in Arch Linux. This change fixes it.
